### PR TITLE
0.0.13 leadingZero parameter added

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-
+android.disableAutomaticComponentCreation=true
 #####################
 ## PUBLISHING
 #####################

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -4,13 +4,14 @@ plugins {
     id("kotlin-android")
     id("common")
 
-    //id("com.vanniktech.maven.publish")
-    `maven-publish`
+    id("com.vanniktech.maven.publish")
+    //`maven-publish`
 }
 
-/*mavenPublish {
+mavenPublish {
     sonatypeHost = com.vanniktech.maven.publish.SonatypeHost.S01
-}*/
+}
+
 repositories {
     google()
     mavenCentral()
@@ -22,7 +23,7 @@ dependencies {
 
     testImplementation("junit:junit:4.13.2")
 }
-publishing {
+/*publishing {
     publications {
         register<MavenPublication>("release") {
             groupId = "com.github.cjrcodes"
@@ -34,4 +35,4 @@ publishing {
             }
         }
     }
-}
+}*/

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -1,12 +1,19 @@
+
 plugins {
     id("com.android.library")
     id("kotlin-android")
     id("common")
-    id("com.vanniktech.maven.publish")
+
+    //id("com.vanniktech.maven.publish")
+    `maven-publish`
 }
 
-mavenPublish {
+/*mavenPublish {
     sonatypeHost = com.vanniktech.maven.publish.SonatypeHost.S01
+}*/
+repositories {
+    google()
+    mavenCentral()
 }
 
 dependencies {
@@ -15,8 +22,16 @@ dependencies {
 
     testImplementation("junit:junit:4.13.2")
 }
+publishing {
+    publications {
+        register<MavenPublication>("release") {
+            groupId = "com.github.cjrcodes"
+            artifactId = "compose-numberpicker"
+            version = "0.0.13"
 
-repositories {
-    google()
-    mavenCentral()
+            afterEvaluate {
+                from(components["release"])
+            }
+        }
+    }
 }

--- a/lib/src/main/kotlin/com/chargemap/compose/numberpicker/HoursNumberPicker.kt
+++ b/lib/src/main/kotlin/com/chargemap/compose/numberpicker/HoursNumberPicker.kt
@@ -34,6 +34,7 @@ data class AMPMHours(
 fun HoursNumberPicker(
     modifier: Modifier = Modifier,
     value: Hours,
+    leadingZero: Boolean,
     hoursRange: Iterable<Int> = when (value) {
         is FullHours -> (0..23)
         is AMPMHours -> (1..12)
@@ -50,6 +51,7 @@ fun HoursNumberPicker(
             FullHoursNumberPicker(
                 modifier = modifier,
                 value = value,
+                leadingZero = leadingZero,
                 hoursRange = hoursRange,
                 minutesRange = minutesRange,
                 hoursDivider = hoursDivider,
@@ -62,6 +64,7 @@ fun HoursNumberPicker(
             AMPMHoursNumberPicker(
                 modifier = modifier,
                 value = value,
+                leadingZero = leadingZero,
                 hoursRange = hoursRange,
                 minutesRange = minutesRange,
                 hoursDivider = hoursDivider,
@@ -77,6 +80,7 @@ fun HoursNumberPicker(
 fun FullHoursNumberPicker(
     modifier: Modifier = Modifier,
     value: FullHours,
+    leadingZero: Boolean,
     hoursRange: Iterable<Int>,
     minutesRange: Iterable<Int> = (0..59),
     hoursDivider: (@Composable () -> Unit)? = null,
@@ -91,6 +95,7 @@ fun FullHoursNumberPicker(
     ) {
         NumberPicker(
             modifier = Modifier.weight(1f),
+            leadingZero = leadingZero,
             value = value.hours,
             onValueChange = {
                 onValueChange(value.copy(hours = it))
@@ -104,6 +109,7 @@ fun FullHoursNumberPicker(
 
         NumberPicker(
             modifier = Modifier.weight(1f),
+            leadingZero = leadingZero,
             value = value.minutes,
             onValueChange = {
                 onValueChange(value.copy(minutes = it))
@@ -121,6 +127,7 @@ fun FullHoursNumberPicker(
 fun AMPMHoursNumberPicker(
     modifier: Modifier = Modifier,
     value: AMPMHours,
+    leadingZero: Boolean,
     hoursRange: Iterable<Int>,
     minutesRange: Iterable<Int> = (0..59),
     hoursDivider: (@Composable () -> Unit)? = null,
@@ -136,6 +143,7 @@ fun AMPMHoursNumberPicker(
         NumberPicker(
             modifier = Modifier.weight(1f),
             value = value.hours,
+            leadingZero = leadingZero,
             onValueChange = {
                 onValueChange(value.copy(hours = it))
             },
@@ -148,6 +156,7 @@ fun AMPMHoursNumberPicker(
 
         NumberPicker(
             modifier = Modifier.weight(1f),
+            leadingZero = leadingZero,
             value = value.minutes,
             onValueChange = {
                 onValueChange(value.copy(minutes = it))
@@ -160,6 +169,7 @@ fun AMPMHoursNumberPicker(
         minutesDivider?.invoke()
 
         NumberPicker(
+            leadingZero = leadingZero,
             value = when (value.dayTime) {
                 AMPMHours.DayTime.AM -> 0
                 else -> 1

--- a/lib/src/main/kotlin/com/chargemap/compose/numberpicker/NumberPicker.kt
+++ b/lib/src/main/kotlin/com/chargemap/compose/numberpicker/NumberPicker.kt
@@ -6,12 +6,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import kotlin.math.abs
 
 @Composable
 fun NumberPicker(
     modifier: Modifier = Modifier,
+    leadingZero: Boolean,
     label: (Int) -> String = {
-        it.toString()
+        "${if(leadingZero && abs(it) < 10) "0" else ""}$it"
     },
     value: Int,
     onValueChange: (Int) -> Unit,

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation("com.google.android.material:material:1.5.0")
     implementation("androidx.appcompat:appcompat:1.4.1")
     implementation("androidx.activity:activity-compose:1.4.0")
+    debugImplementation("androidx.compose.ui:ui-tooling:${Versions.compose}")
 
     testImplementation("junit:junit:4.13.2")
 }

--- a/sample/src/main/kotlin/com/chargemap/android/sample/PreviewComponents.kt
+++ b/sample/src/main/kotlin/com/chargemap/android/sample/PreviewComponents.kt
@@ -18,14 +18,14 @@ import com.chargemap.compose.numberpicker.*
 @Composable
 private fun NumberPickerPreview() {
     var state by remember { mutableStateOf(0) }
-    com.chargemap.compose.numberpicker.NumberPicker(
+    NumberPicker(
         leadingZero = true,
         value = state,
         range = 0..10,
         onValueChange = {
             state = it
         },
-                textStyle = TextStyle(Color.White)
+        textStyle = TextStyle(Color.White)
 
     )
 }
@@ -51,7 +51,7 @@ private fun HoursNumberPicker1Preview() {
                 text = ":"
             )
         },
-    textStyle = TextStyle(Color.White)
+        textStyle = TextStyle(Color.White)
     )
 }
 

--- a/sample/src/main/kotlin/com/chargemap/android/sample/PreviewComponents.kt
+++ b/sample/src/main/kotlin/com/chargemap/android/sample/PreviewComponents.kt
@@ -1,75 +1,44 @@
-package com.chargemap.android.sample
-
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.chargemap.compose.numberpicker.*
 
+
+@Preview
 @Composable
-fun MainActivityUI() {
-
-    val scrollState = rememberScrollState()
-
-    MaterialTheme {
-        Scaffold(
-            topBar = {
-                TopAppBar(title = { Text(stringResource(id = R.string.app_name)) })
-            }
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .verticalScroll(scrollState)
-            ) {
-                Column(
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp)
-                ) {
-                    NumberPicker()
-                    HoursNumberPicker1()
-                    HoursNumberPicker2()
-                    HoursNumberPicker3()
-                    HoursNumberPicker4()
-                    DoublesPicker()
-                    FruitPicker()
-                    IntRangePicker()
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun NumberPicker() {
+private fun NumberPickerPreview() {
     var state by remember { mutableStateOf(0) }
-    NumberPicker(
+    com.chargemap.compose.numberpicker.NumberPicker(
         leadingZero = true,
         value = state,
         range = 0..10,
         onValueChange = {
             state = it
-        }
+        },
+                textStyle = TextStyle(Color.White)
+
     )
 }
 
+@Preview
 @Composable
-private fun HoursNumberPicker1() {
-    var state by remember { mutableStateOf<Hours>(FullHours(12, 43)) }
+private fun HoursNumberPicker1Preview() {
+    var state by remember { mutableStateOf<Hours>(FullHours(12, 0)) }
     HoursNumberPicker(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 16.dp),        leadingZero = true,
-
+            .padding(vertical = 16.dp),
+        leadingZero = true,
         dividersColor = MaterialTheme.colors.error,
         value = state,
         onValueChange = {
@@ -81,18 +50,20 @@ private fun HoursNumberPicker1() {
                 textAlign = TextAlign.Center,
                 text = ":"
             )
-        }
+        },
+    textStyle = TextStyle(Color.White)
     )
 }
 
+@Preview
 @Composable
-private fun HoursNumberPicker2() {
-    var state by remember { mutableStateOf<Hours>(AMPMHours(9, 43, AMPMHours.DayTime.PM)) }
+private fun HoursNumberPicker2Preview() {
+    var state by remember { mutableStateOf<Hours>(AMPMHours(9, 0, AMPMHours.DayTime.PM)) }
     HoursNumberPicker(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 16.dp),        leadingZero = true,
-
+            .padding(vertical = 16.dp),
+        leadingZero = true,
         dividersColor = MaterialTheme.colors.secondary,
         value = state,
         onValueChange = {
@@ -109,23 +80,26 @@ private fun HoursNumberPicker2() {
             Spacer(
                 modifier = Modifier.size(24.dp),
             )
-        }
+        },
+        textStyle = TextStyle(Color.White)
     )
 }
 
+@Preview
 @Composable
-private fun HoursNumberPicker3() {
+private fun HoursNumberPicker3Preview() {
     var state by remember { mutableStateOf<Hours>(FullHours(9, 20)) }
 
     HoursNumberPicker(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 16.dp),        leadingZero = true,
-
+            .padding(vertical = 16.dp),
         value = state,
         onValueChange = {
             state = it
         },
+        leadingZero = true,
+
         minutesRange = IntProgression.fromClosedRange(0, 50, 10),
         hoursDivider = {
             Text(
@@ -140,18 +114,20 @@ private fun HoursNumberPicker3() {
                 textAlign = TextAlign.Center,
                 text = "m"
             )
-        }
+        },
+        textStyle = TextStyle(Color.White)
     )
 }
 
+@Preview
 @Composable
-private fun HoursNumberPicker4() {
+private fun HoursNumberPicker4Preview() {
     var state by remember { mutableStateOf<Hours>(FullHours(11, 36)) }
     HoursNumberPicker(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 16.dp),        leadingZero = true,
-
+            .padding(vertical = 16.dp),
+        leadingZero = true,
         value = state,
         onValueChange = {
             state = it
@@ -169,12 +145,14 @@ private fun HoursNumberPicker4() {
                 textAlign = TextAlign.Center,
                 text = "minutes"
             )
-        }
+        },
+        textStyle = TextStyle(Color.White)
     )
 }
 
+@Preview
 @Composable
-private fun DoublesPicker() {
+private fun DoublesPickerPreview() {
     val possibleValues = generateSequence(0.5f, { it + 0.25f })
         .takeWhile { it <= 5f }
         .toList()
@@ -183,12 +161,14 @@ private fun DoublesPicker() {
         label = { it.toString() },
         value = state,
         onValueChange = { state = it },
-        list = possibleValues
+        list = possibleValues,
+        textStyle = TextStyle(Color.White)
     )
 }
 
+@Preview
 @Composable
-private fun FruitPicker() {
+private fun FruitPickerPreview() {
     val possibleValues = listOf("🍎", "🍊", "🍉", "🥭", "🍈", "🍇", "🍍")
     var state by remember { mutableStateOf(possibleValues[0]) }
     ListItemPicker(
@@ -199,14 +179,16 @@ private fun FruitPicker() {
     )
 }
 
+@Preview
 @Composable
-private fun IntRangePicker() {
+private fun IntRangePickerPreview() {
     val possibleValues = (-5..10).toList()
     var value by remember { mutableStateOf(possibleValues[0]) }
     ListItemPicker(
         label = { it.toString() },
         value = value,
         onValueChange = { value = it },
-        list = possibleValues
+        list = possibleValues,
+        textStyle = TextStyle(Color.White)
     )
 }


### PR DESCRIPTION
0.0.13, leadingZero boolean parameter added. When true, numbers less than 10 (and greater than -10) will display an extra leading 0, useful for displaying time formats accurately (e.g. leadingZero = true, 01:05 PM / leadingZero = false, 1:5 PM)

currently accessible through: https://jitpack.io/#cjrcodes/Compose-NumberPicker/0.0.13

build.gradle: app:
implementation "com.github.cjrcodes:Compose-NumberPicker:0.0.13"

build.gradle:
maven { url 'https://jitpack.io' }



