### PR TITLE
Add support to custom selected textStyle

### DIFF
--- a/lib/src/main/kotlin/com/chargemap/compose/numberpicker/HoursNumberPicker.kt
+++ b/lib/src/main/kotlin/com/chargemap/compose/numberpicker/HoursNumberPicker.kt
@@ -46,6 +46,7 @@ fun HoursNumberPicker(
     onValueChange: (Hours) -> Unit,
     dividersColor: Color = MaterialTheme.colors.primary,
     textStyle: TextStyle = LocalTextStyle.current,
+    selectedTextStyle: TextStyle = LocalTextStyle.current,
 ) {
     when (value) {
         is FullHours ->
@@ -60,6 +61,7 @@ fun HoursNumberPicker(
                 onValueChange = onValueChange,
                 dividersColor = dividersColor,
                 textStyle = textStyle,
+                selectedTextStyle = selectedTextStyle,
             )
         is AMPMHours ->
             AMPMHoursNumberPicker(
@@ -73,6 +75,7 @@ fun HoursNumberPicker(
                 onValueChange = onValueChange,
                 dividersColor = dividersColor,
                 textStyle = textStyle,
+                selectedTextStyle = selectedTextStyle,
             )
     }
 }
@@ -89,6 +92,7 @@ fun FullHoursNumberPicker(
     onValueChange: (Hours) -> Unit,
     dividersColor: Color = MaterialTheme.colors.primary,
     textStyle: TextStyle = LocalTextStyle.current,
+    selectedTextStyle: TextStyle = LocalTextStyle.current,
 ) {
     Row(
         modifier = modifier,
@@ -105,6 +109,7 @@ fun FullHoursNumberPicker(
             },
             dividersColor = dividersColor,
             textStyle = textStyle,
+            selectedTextStyle = selectedTextStyle,
             range = hoursRange
         )
 
@@ -121,6 +126,7 @@ fun FullHoursNumberPicker(
             },
             dividersColor = dividersColor,
             textStyle = textStyle,
+            selectedTextStyle = selectedTextStyle,
             range = minutesRange
         )
 
@@ -140,6 +146,7 @@ fun AMPMHoursNumberPicker(
     onValueChange: (Hours) -> Unit,
     dividersColor: Color = MaterialTheme.colors.primary,
     textStyle: TextStyle = LocalTextStyle.current,
+    selectedTextStyle: TextStyle = LocalTextStyle.current,
 ) {
     Row(
         modifier = modifier,
@@ -156,6 +163,7 @@ fun AMPMHoursNumberPicker(
             },
             dividersColor = dividersColor,
             textStyle = textStyle,
+            selectedTextStyle = selectedTextStyle,
             range = hoursRange
         )
 
@@ -172,6 +180,7 @@ fun AMPMHoursNumberPicker(
             },
             dividersColor = dividersColor,
             textStyle = textStyle,
+            selectedTextStyle = selectedTextStyle,
             range = minutesRange
         )
 
@@ -200,6 +209,7 @@ fun AMPMHoursNumberPicker(
             },
             dividersColor = dividersColor,
             textStyle = textStyle,
+            selectedTextStyle = selectedTextStyle,
             range = (0..1)
         )
     }

--- a/lib/src/main/kotlin/com/chargemap/compose/numberpicker/ListItemPicker.kt
+++ b/lib/src/main/kotlin/com/chargemap/compose/numberpicker/ListItemPicker.kt
@@ -2,15 +2,9 @@ package com.chargemap.compose.numberpicker
 
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.gestures.draggable
-import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.gestures.*
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.ProvideTextStyle
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,6 +40,7 @@ fun <T> ListItemPicker(
     dividersColor: Color = MaterialTheme.colors.primary,
     list: List<T>,
     textStyle: TextStyle = LocalTextStyle.current,
+    selectedTextStyle: TextStyle = LocalTextStyle.current,
 ) {
     val minimumAlpha = 0.3f
     val verticalMargin = 8.dp
@@ -117,32 +112,33 @@ fun <T> ListItemPicker(
                     .offset { IntOffset(x = 0, y = coercedAnimatedOffset.roundToInt()) }
             ) {
                 val baseLabelModifier = Modifier.align(Alignment.Center)
-                ProvideTextStyle(textStyle) {
-                    if (indexOfElement > 0)
-                        Label(
-                            text = label(list.elementAt(indexOfElement - 1)),
-                            modifier = baseLabelModifier
-                                .offset(y = -halfNumbersColumnHeight)
-                                .alpha(maxOf(minimumAlpha, coercedAnimatedOffset / halfNumbersColumnHeightPx))
-                        )
+                if (indexOfElement > 0)
                     Label(
-                        text = label(list.elementAt(indexOfElement)),
+                        text = label(list.elementAt(indexOfElement - 1)),
+                        textStyle = textStyle,
                         modifier = baseLabelModifier
-                            .alpha(
-                                (maxOf(
-                                    minimumAlpha,
-                                    1 - abs(coercedAnimatedOffset) / halfNumbersColumnHeightPx
-                                ))
-                            )
+                            .offset(y = -halfNumbersColumnHeight)
+                            .alpha(maxOf(minimumAlpha, coercedAnimatedOffset / halfNumbersColumnHeightPx))
                     )
-                    if (indexOfElement < list.count() - 1)
-                        Label(
-                            text = label(list.elementAt(indexOfElement + 1)),
-                            modifier = baseLabelModifier
-                                .offset(y = halfNumbersColumnHeight)
-                                .alpha(maxOf(minimumAlpha, -coercedAnimatedOffset / halfNumbersColumnHeightPx))
+                Label(
+                    text = label(list.elementAt(indexOfElement)),
+                    textStyle = selectedTextStyle,
+                    modifier = baseLabelModifier
+                        .alpha(
+                            (maxOf(
+                                minimumAlpha,
+                                1 - abs(coercedAnimatedOffset) / halfNumbersColumnHeightPx
+                            ))
                         )
-                }
+                )
+                if (indexOfElement < list.count() - 1)
+                    Label(
+                        text = label(list.elementAt(indexOfElement + 1)),
+                        textStyle = textStyle,
+                        modifier = baseLabelModifier
+                            .offset(y = halfNumbersColumnHeight)
+                            .alpha(maxOf(minimumAlpha, -coercedAnimatedOffset / halfNumbersColumnHeightPx))
+                    )
             }
             Box(
                 modifier
@@ -188,7 +184,11 @@ fun <T> ListItemPicker(
 }
 
 @Composable
-private fun Label(text: String, modifier: Modifier) {
+private fun Label(
+    text: String,
+    textStyle: TextStyle,
+    modifier: Modifier
+) {
     Text(
         modifier = modifier.pointerInput(Unit) {
             detectTapGestures(onLongPress = {
@@ -196,6 +196,7 @@ private fun Label(text: String, modifier: Modifier) {
             })
         },
         text = text,
+        style = textStyle,
         textAlign = TextAlign.Center,
     )
 }

--- a/lib/src/main/kotlin/com/chargemap/compose/numberpicker/NumberPicker.kt
+++ b/lib/src/main/kotlin/com/chargemap/compose/numberpicker/NumberPicker.kt
@@ -18,6 +18,7 @@ fun NumberPicker(
     dividersColor: Color = MaterialTheme.colors.primary,
     range: Iterable<Int>,
     textStyle: TextStyle = LocalTextStyle.current,
+    selectedTextStyle: TextStyle = LocalTextStyle.current,
 ) {
     ListItemPicker(
         modifier = modifier,
@@ -26,6 +27,7 @@ fun NumberPicker(
         onValueChange = onValueChange,
         dividersColor = dividersColor,
         list = range.toList(),
-        textStyle = textStyle
+        textStyle = textStyle,
+        selectedTextStyle = selectedTextStyle
     )
 }

--- a/sample/src/main/kotlin/com/chargemap/android/sample/MainActivityUI.kt
+++ b/sample/src/main/kotlin/com/chargemap/android/sample/MainActivityUI.kt
@@ -3,13 +3,12 @@ package com.chargemap.android.sample
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
+import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.chargemap.compose.numberpicker.*
@@ -57,7 +56,9 @@ private fun NumberPicker() {
         range = 0..10,
         onValueChange = {
             state = it
-        }
+        },
+        textStyle = TextStyle(),
+        selectedTextStyle = TextStyle(fontWeight = FontWeight.Bold)
     )
 }
 
@@ -80,7 +81,9 @@ private fun HoursNumberPicker1() {
                 textAlign = TextAlign.Center,
                 text = ":"
             )
-        }
+        },
+        textStyle = TextStyle(),
+        selectedTextStyle = TextStyle(fontWeight = FontWeight.Bold)
     )
 }
 
@@ -182,7 +185,9 @@ private fun DoublesPicker() {
         label = { it.toString() },
         value = state,
         onValueChange = { state = it },
-        list = possibleValues
+        list = possibleValues,
+        textStyle = TextStyle(),
+        selectedTextStyle = TextStyle(fontWeight = FontWeight.Bold)
     )
 }
 

--- a/sample/src/main/kotlin/com/chargemap/android/sample/PreviewComponents.kt
+++ b/sample/src/main/kotlin/com/chargemap/android/sample/PreviewComponents.kt
@@ -1,13 +1,11 @@
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -23,7 +21,8 @@ private fun NumberPickerPreview() {
         onValueChange = {
             state = it
         },
-        textStyle = TextStyle(Color.White)
+        textStyle = TextStyle(Color.White),
+        selectedTextStyle = TextStyle(Color.White, fontWeight = FontWeight.Bold)
     )
 }
 
@@ -48,7 +47,8 @@ private fun HoursNumberPicker1Preview() {
                 text = ":"
             )
         },
-        textStyle = TextStyle(Color.White)
+        textStyle = TextStyle(Color.White),
+        selectedTextStyle = TextStyle(Color.White, fontWeight = FontWeight.Bold)
     )
 }
 
@@ -159,7 +159,8 @@ private fun DoublesPickerPreview() {
         value = state,
         onValueChange = { state = it },
         list = possibleValues,
-        textStyle = TextStyle(Color.White)
+        textStyle = TextStyle(Color.White),
+        selectedTextStyle = TextStyle(Color.White, fontWeight = FontWeight.Bold)
     )
 }
 


### PR DESCRIPTION
## What happened 👀

Currently, the library does not support customizing `textStyle` for selected items.

## Insight 📝

- Add new attr `selectedTextStyle` along with `textStyle` to custom textStyle for selected items.

## Proof Of Work 📹

<img src="https://user-images.githubusercontent.com/16315358/217329887-df6f40db-7c4b-4992-b3ef-382440ceb10f.png" width=300 />

